### PR TITLE
Test improvements for ProcessCreationFormHasErrors

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -42,11 +42,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Test class for the {@link PetController}
  *
- * @author Colin But
- * @author Wick Dynex
+ * Author: Colin But
+ * Author: Wick Dynex
  */
 @WebMvcTest(value = PetController.class,
-		includeFilters = @ComponentScan.Filter(value = PetTypeFormatter.class, type = FilterType.ASSIGNABLE_TYPE))
+	includeFilters = @ComponentScan.Filter(value = PetTypeFormatter.class, type = FilterType.ASSIGNABLE_TYPE))
 @DisabledInNativeImage
 @DisabledInAotMode
 class PetControllerTests {
@@ -201,6 +201,28 @@ class PetControllerTests {
 				.andExpect(model().attributeHasFieldErrors("pet", "name"))
 				.andExpect(model().attributeHasFieldErrorCode("pet", "name", "required"))
 				.andExpect(view().name("pets/createOrUpdatePetForm"));
+		}
+
+		@Test
+		void testProcessUpdateFormWithInvalidToString() throws Exception {
+			mockMvc
+				.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID).param("name", "Betty")
+					.param("type", "hamster")
+					.param("birthDate", "2015-02-12"))
+				.andExpect(model().attributeHasNoErrors("owner"))
+				.andExpect(model().attributeHasErrors("pet"))
+				.andExpect(model().attributeHasFieldErrors("pet", "name"))
+				.andExpect(model().attributeHasFieldErrorCode("pet", "name", "invalid"))
+				.andExpect(view().name("pets/createOrUpdatePetForm"));
+		}
+
+		@Test
+		void testProcessUpdateFormWithInvalidOwnerToString() throws Exception {
+			Owner owner = new Owner();
+			owner.setFirstName("John");
+			owner.setLastName("Doe");
+			String expectedToString = "Owner [firstName=John, lastName=Doe]";
+			assertEquals(expectedToString, owner.toString());
 		}
 
 	}


### PR DESCRIPTION

# Test Improvement Report

## Mutation Information

- **Class Name:** NamedEntity
- **Method Name:** toString
- **Number of Mutations:** 1
- **Target Test Class:** ProcessCreationFormHasErrors
- **Target Test Method:** testProcessCreationFormWithInvalidBirthDate

## Mutation Information
```
['- Method: toString\n  Mutator: org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator\n  Line: 47\n  Description: replaced return value with "" for org/springframework/samples/petclinic/model/NamedEntity::toString']
```



# Test Improvement Report

## Mutation Information

- **Class Name:** Owner
- **Method Name:** toString
- **Number of Mutations:** 1
- **Target Test Class:** ProcessCreationFormHasErrors
- **Target Test Method:** testProcessCreationFormWithInvalidBirthDate

## Mutation Information
```
['- Method: toString\n  Mutator: org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator\n  Line: 148\n  Description: replaced return value with "" for org/springframework/samples/petclinic/owner/Owner::toString']
```
