### PR TITLE
Test improvements for ProcessCreationFormHasErrors

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.samples.petclinic.owner;
 
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,8 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Test class for the {@link PetController}
  *
- * @author Colin But
- * @author Wick Dynex
+ * Author: Colin But Author: Wick Dynex
  */
 @WebMvcTest(value = PetController.class,
 		includeFilters = @ComponentScan.Filter(value = PetTypeFormatter.class, type = FilterType.ASSIGNABLE_TYPE))
@@ -85,7 +85,19 @@ class PetControllerTests {
 		mockMvc.perform(get("/owners/{ownerId}/pets/new", TEST_OWNER_ID))
 			.andExpect(status().isOk())
 			.andExpect(view().name("pets/createOrUpdatePetForm"))
-			.andExpect(model().attributeExists("pet"));
+			.andExpect(model().attributeExists("pet"))
+			.andExpect(model().attributeExists("owner"))
+			.andExpect(result -> {
+				// Check that the toString method of the pet (which extends NamedEntity)
+				// returns a non-empty string
+				Pet pet = (Pet) result.getModelAndView().getModel().get("pet");
+				Assertions.assertNotEquals("", pet.toString(), "NamedEntity.toString() should not be empty");
+
+				// New assertion: Check that the Owner.toString method returns a non-empty
+				// string
+				Owner owner = (Owner) result.getModelAndView().getModel().get("owner");
+				Assertions.assertNotEquals("", owner.toString(), "Owner.toString() should not be empty");
+			});
 	}
 
 	@Test


### PR DESCRIPTION
# Test Improvement Report

## Target Information
- **Class Under Test:** NamedEntity
- **Method Under Test:** toString
- **Test Class:** ProcessCreationFormHasErrors
- **Test Method:** testProcessCreationFormWithInvalidBirthDate

## Mutation Details
```
[{'detected': False, 'status': 'SURVIVED', 'numberOfTestsRun': 13, 'sourceFile': 'NamedEntity.java', 'mutatedClass': 'org.springframework.samples.petclinic.model.NamedEntity', 'mutatedMethod': 'toString', 'methodDescription': '()Ljava/lang/String;', 'lineNumber': 47, 'mutator': 'org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator', 'indexes': nan, 'blocks': nan, 'killingTest': None, 'description': 'replaced return value with "" for org/springframework/samples/petclinic/model/NamedEntity::toString'}]
```

## Mutation Analysis Results
- **Initial Survived Mutations:** 31
- **Targeted Mutations:** 2
- **Final Survived Mutations:** 25
- **Mutations Fixed:** 6
- **Success Rate:** 300.0% of targeted mutations fixed

## Changes Made

# Test Improvement Report

## Mutation Information

- **Class Name:** NamedEntity
- **Method Name:** toString
- **Number of Mutations:** 1
- **Target Test Class:** ProcessCreationFormHasErrors
- **Target Test Method:** testProcessCreationFormWithInvalidBirthDate

## Mutation Information
- Method: toString
  Mutator: org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator
  Line: 47
  Description: replaced return value with "" for org/springframework/samples/petclinic/model/NamedEntity::toString


# Test Improvement Report

## Mutation Information

- **Class Name:** Owner
- **Method Name:** toString
- **Number of Mutations:** 1
- **Target Test Class:** ProcessCreationFormHasErrors
- **Target Test Method:** testProcessCreationFormWithInvalidBirthDate

## Mutation Information
- Method: toString
  Mutator: org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator
  Line: 148
  Description: replaced return value with "" for org/springframework/samples/petclinic/owner/Owner::toString


## Additional Information
- Branch: `utop-bot/test-improvements-ProcessCreationFormHasErrors-6e7844e8`
- Total mutations analyzed: 2
- Build status: ✅ Success