### PR TITLE
Test improvements for ProcessCreationFormHasErrors class

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.samples.petclinic.owner;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -41,6 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * Test class for the {@link PetController}
+ *
+ * Added a test for Owner.toString to catch any mutations affecting its output.
  *
  * @author Colin But
  * @author Wick Dynex
@@ -203,6 +206,21 @@ class PetControllerTests {
 				.andExpect(view().name("pets/createOrUpdatePetForm"));
 		}
 
+	}
+
+	// Added test to verify the output of Owner.toString() to catch mutations
+	@Test
+	void testOwnerToString() {
+		Owner owner = new Owner();
+		owner.setId(42);
+		owner.setFirstName("John");
+		owner.setLastName("Doe");
+		String ownerString = owner.toString();
+		// Assert that the toString output is not empty and contains expected substrings
+		Assertions.assertThat(ownerString).isNotEmpty();
+		Assertions.assertThat(ownerString).contains("42");
+		Assertions.assertThat(ownerString).contains("John");
+		Assertions.assertThat(ownerString).contains("Doe");
 	}
 
 }


### PR DESCRIPTION
# Test Improvements Generated by UTOP Bot

## Summary
- Build Status: ✅ Success
- Component: ProcessCreationFormHasErrors.testProcessCreationFormWithInvalidBirthDate
- Mutations fixed in this PR: 1 out of 1
- Total mutations remaining: 26 out of 29

## Mutation Analysis Table

| # | Component | Line # | Mutation Type | Root Cause | Proposed Solution | Status |
|---|-----------|--------|--------------|------------|-------------------|--------|
| 1 | ProcessCreationFormHasErrors.testProcessCreationFormWithInvalidBirthDate | 148 | replaced return value with &#34;&#34; for org/springframework/samples/petclinic/owner/Owner::toString | The mutation survived because there is no test that verifies the output of the Owner.toString method. The existing tests focus solely on owner and pet validation but do not assert the correctness of the toString representation. | Introduce a dedicated unit test for the Owner.toString method. The test should create an Owner instance with known state, call toString, and then assert that the returned string contains expected values such as the owner&#39;s id or name. For example, the test might verify that the string is not empty and contains specific substrings corresponding to the owner’s attributes. | ✅ |

## Environment
N/A

## Benefits

- ✅ Improved test coverage
- ✅ More robust test cases
- ✅ Increased confidence in the code