### PR TITLE
Test improvements for OwnerControllerTests class

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -40,6 +40,9 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,13 +50,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 /**
  * Test class for {@link OwnerController}
  *
- * @author Colin But
- * @author Wick Dynex
+ * Author: Colin But, Wick Dynex
  */
 @WebMvcTest(OwnerController.class)
 @DisabledInNativeImage
@@ -166,7 +172,6 @@ class OwnerControllerTests {
 			.andExpect(model().attributeHasFieldErrors("owner", "lastName"))
 			.andExpect(model().attributeHasFieldErrorCode("owner", "lastName", "notFound"))
 			.andExpect(view().name("owners/findOwners"));
-
 	}
 
 	@Test
@@ -248,6 +253,23 @@ class OwnerControllerTests {
 			.andExpect(status().is3xxRedirection())
 			.andExpect(redirectedUrl("/owners/" + pathOwnerId + "/edit"))
 			.andExpect(flash().attributeExists("error"));
+	}
+
+	// Additional tests added to directly validate Owner.getPet behavior to kill the
+	// mutation
+	@Test
+	void testGetExistingPet() {
+		Owner owner = george();
+		Pet pet = owner.getPet("Max");
+		assertNotNull(pet, "Expected to find pet named 'Max'");
+		assertEquals("Max", pet.getName(), "The returned pet should have the name 'Max'");
+	}
+
+	@Test
+	void testGetNonExistingPet() {
+		Owner owner = george();
+		Pet pet = owner.getPet("Unknown");
+		assertNull(pet, "Expected null when no pet matches the given name");
 	}
 
 }


### PR DESCRIPTION
# Test Improvements Generated by UTOP Bot

## Summary
- Build Status: ✅ Success
- Component: OwnerControllerTests.setup
- Mutations fixed in this PR: 1 out of 3
- Total mutations remaining: 40 out of 40

## Mutation Analysis Table

| # | Component | Mutation Type | Root Cause | Proposed Solution | Status |
|---|-----------|--------------|------------|-------------------|--------|
| 1 | OwnerControllerTests.setup | NegateConditionalsMutator | The mutation survived because current tests only indirectly invoke getPet in the context of adding a visit, without verifying its correct behavior under both matching and non-matching conditions. | Add focused tests for Owner.getPet that check: a) it returns the correct pet when the name matches an existing pet, and b) it returns null when no pet matches the provided name. | ✅ |

## Environment
N/A

## Benefits

- ✅ Improved test coverage
- ✅ More robust test cases
- ✅ Increased confidence in the code