### PR TITLE
Test improvements for org.springframework.samples.petclinic.owner.OwnerControllerTests class

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -217,6 +217,9 @@ class OwnerControllerTests {
 
 	@Test
 	void testShowOwner() throws Exception {
+		// Retrieve the owner instance for direct testing of getPet method behavior
+		Owner owner = george();
+
 		mockMvc.perform(get("/owners/{ownerId}", TEST_OWNER_ID))
 			.andExpect(status().isOk())
 			.andExpect(model().attribute("owner", hasProperty("lastName", is("Franklin"))))
@@ -228,6 +231,12 @@ class OwnerControllerTests {
 			.andExpect(model().attribute("owner",
 					hasProperty("pets", hasItem(hasProperty("visits", hasSize(greaterThan(0)))))))
 			.andExpect(view().name("owners/ownerDetails"));
+
+		// Additional assertions to test the getPet method behavior
+		// Verify that getPet returns the pet when the name matches exactly
+		org.junit.jupiter.api.Assertions.assertNotNull(owner.getPet("Max"), "Expected getPet('Max') not to be null");
+		// Verify that getPet returns null when no pet with the given name is found
+		org.junit.jupiter.api.Assertions.assertNull(owner.getPet("Kitty"), "Expected getPet('Kitty') to be null");
 	}
 
 	@Test


### PR DESCRIPTION
# Test Improvements Generated by UTOP Bot

## Summary
- Build Status: ✅ Success
- Component: org.springframework.samples.petclinic.owner.OwnerControllerTests.setup
- Mutations fixed in this PR: 0 out of 3
- Total mutations remaining: 40 out of 36

## Mutation Analysis Table

| # | Component | Mutation Type | Root Cause | Proposed Solution | Status |
|---|-----------|--------------|------------|-------------------|--------|
| 1 | org.springframework.samples.petclinic.owner.OwnerControllerTests.setup | NegateConditionalsMutator | The mutation survived because the existing tests only validate the positive scenario where getPet returns a valid pet. They do not thoroughly test the negative branch (i.e., when the pet is not found) to catch the negation error. | Introduce additional tests that cover both branches of the conditional in getPet. Specifically, add tests that: 1) Verify that a pet is returned when the name matches exactly, and 2) Verify that null is returned when no pet with the given name is found. | ❌ |

## Environment
N/A

## Benefits

- ✅ Improved test coverage
- ✅ More robust test cases
- ✅ Increased confidence in the code